### PR TITLE
Dynamic Frameworks for iOS / OS X and Carthage Supports

### DIFF
--- a/Versions.xcodeproj/project.pbxproj
+++ b/Versions.xcodeproj/project.pbxproj
@@ -299,7 +299,8 @@
 		BDD8224D1AA45FDD00E48CEF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0640;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					03C709DE1B24205A00609F81 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -491,6 +492,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Version;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -541,6 +543,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Version;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -599,6 +602,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Version;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -649,6 +653,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Version;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -699,6 +704,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -740,6 +746,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -791,6 +798,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VersionsDemo.app/VersionsDemo";
@@ -835,6 +843,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VersionsDemo.app/VersionsDemo";
@@ -845,6 +854,7 @@
 		BDD822511AA45FDD00E48CEF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -865,6 +875,7 @@
 				03C709F91B24205A00609F81 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		03C70A4D1B24210C00609F81 /* Build configuration list for PBXNativeTarget "Versions-OSX" */ = {
 			isa = XCConfigurationList;
@@ -873,6 +884,7 @@
 				03C70A4F1B24210C00609F81 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		BD87D1C31B0CD38B00244049 /* Build configuration list for PBXNativeTarget "VersionsDemo" */ = {
 			isa = XCConfigurationList;

--- a/Versions.xcodeproj/project.pbxproj
+++ b/Versions.xcodeproj/project.pbxproj
@@ -7,21 +7,32 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B57C8ACC1AB0D2C700430F04 /* StaticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C8ACB1AB0D2C700430F04 /* StaticVersion.swift */; };
-		B5C5053A1AB0DA010090B67A /* StaticVersion_Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C505391AB0DA010090B67A /* StaticVersion_Test.swift */; };
+		03C709F61B24205A00609F81 /* Version.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03C709DF1B24205A00609F81 /* Version.framework */; };
+		03C709F71B24205A00609F81 /* Version.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03C709DF1B24205A00609F81 /* Version.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		03C70A021B24209D00609F81 /* StaticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C709FF1B24209D00609F81 /* StaticVersion.swift */; };
+		03C70A031B24209D00609F81 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C70A001B24209D00609F81 /* Versions.h */; };
+		03C70A041B24209D00609F81 /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C70A011B24209D00609F81 /* Versions.swift */; };
+		03C70A531B24216B00609F81 /* StaticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C709FF1B24209D00609F81 /* StaticVersion.swift */; };
+		03C70A541B24216B00609F81 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C70A001B24209D00609F81 /* Versions.h */; };
+		03C70A551B24216B00609F81 /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C70A011B24209D00609F81 /* Versions.swift */; };
+		03C70A5A1B2421B000609F81 /* StaticVersion_Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C70A561B2421B000609F81 /* StaticVersion_Test.swift */; };
+		03C70A5B1B2421B000609F81 /* Versions_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C70A571B2421B000609F81 /* Versions_Tests.swift */; };
+		03C70A5C1B2421B000609F81 /* VersionsDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C70A581B2421B000609F81 /* VersionsDemoTests.swift */; };
 		BD87D1A51B0CD38A00244049 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD87D1A41B0CD38A00244049 /* AppDelegate.swift */; };
 		BD87D1AA1B0CD38A00244049 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD87D1A91B0CD38A00244049 /* ViewController.swift */; };
 		BD87D1AD1B0CD38A00244049 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD87D1AB1B0CD38A00244049 /* Main.storyboard */; };
 		BD87D1AF1B0CD38A00244049 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD87D1AE1B0CD38A00244049 /* Images.xcassets */; };
 		BD87D1B21B0CD38A00244049 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD87D1B01B0CD38A00244049 /* LaunchScreen.xib */; };
-		BD87D1BE1B0CD38B00244049 /* VersionsDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD87D1BD1B0CD38B00244049 /* VersionsDemoTests.swift */; };
-		BD87D1C51B0CD45700244049 /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD822681AA4609000E48CEF /* Versions.swift */; };
-		BD87D1C61B0CD68700244049 /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD822681AA4609000E48CEF /* Versions.swift */; };
-		BDD8225D1AA4608000E48CEF /* Versions_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD8225C1AA4608000E48CEF /* Versions_Tests.swift */; };
-		BDD822691AA4609000E48CEF /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD822681AA4609000E48CEF /* Versions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		03C709F41B24205A00609F81 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BDD8224D1AA45FDD00E48CEF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 03C709DE1B24205A00609F81;
+			remoteInfo = Versions;
+		};
 		BD87D1B81B0CD38B00244049 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BDD8224D1AA45FDD00E48CEF /* Project object */;
@@ -31,9 +42,30 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		03C709FD1B24205A00609F81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				03C709F71B24205A00609F81 /* Version.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		B57C8ACB1AB0D2C700430F04 /* StaticVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticVersion.swift; sourceTree = "<group>"; };
-		B5C505391AB0DA010090B67A /* StaticVersion_Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticVersion_Test.swift; sourceTree = "<group>"; };
+		03C709DF1B24205A00609F81 /* Version.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Version.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		03C709E21B24205A00609F81 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03C709FF1B24209D00609F81 /* StaticVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticVersion.swift; sourceTree = "<group>"; };
+		03C70A001B24209D00609F81 /* Versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Versions.h; sourceTree = "<group>"; };
+		03C70A011B24209D00609F81 /* Versions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versions.swift; sourceTree = "<group>"; };
+		03C70A341B24210C00609F81 /* Version.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Version.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		03C70A561B2421B000609F81 /* StaticVersion_Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticVersion_Test.swift; sourceTree = "<group>"; };
+		03C70A571B2421B000609F81 /* Versions_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versions_Tests.swift; sourceTree = "<group>"; };
+		03C70A581B2421B000609F81 /* VersionsDemoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionsDemoTests.swift; sourceTree = "<group>"; };
 		BD87D1A01B0CD38A00244049 /* VersionsDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VersionsDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD87D1A31B0CD38A00244049 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BD87D1A41B0CD38A00244049 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -43,21 +75,31 @@
 		BD87D1B11B0CD38A00244049 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		BD87D1B71B0CD38B00244049 /* VersionsDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VersionsDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD87D1BC1B0CD38B00244049 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BD87D1BD1B0CD38B00244049 /* VersionsDemoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsDemoTests.swift; sourceTree = "<group>"; };
-		BDD822571AA4608000E48CEF /* Versions Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Versions Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BDD8225B1AA4608000E48CEF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BDD8225C1AA4608000E48CEF /* Versions_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Versions_Tests.swift; sourceTree = "<group>"; };
 		BDD822611AA4608500E48CEF /* Versions.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Versions.podspec; sourceTree = "<group>"; };
 		BDD822621AA4608500E48CEF /* LICENSE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		BDD822631AA4608500E48CEF /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		BDD822681AA4609000E48CEF /* Versions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		03C709DB1B24205A00609F81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03C70A301B24210C00609F81 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BD87D19D1B0CD38A00244049 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03C709F61B24205A00609F81 /* Version.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,16 +110,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BDD822541AA4608000E48CEF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03C709E01B24205A00609F81 /* Versions */ = {
+			isa = PBXGroup;
+			children = (
+				03C70A001B24209D00609F81 /* Versions.h */,
+				03C709FF1B24209D00609F81 /* StaticVersion.swift */,
+				03C70A011B24209D00609F81 /* Versions.swift */,
+				03C709E11B24205A00609F81 /* Supporting Files */,
+			);
+			path = Versions;
+			sourceTree = "<group>";
+		};
+		03C709E11B24205A00609F81 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				03C709E21B24205A00609F81 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		BD87D1A11B0CD38A00244049 /* VersionsDemo */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,7 +156,9 @@
 		BD87D1BA1B0CD38B00244049 /* VersionsDemoTests */ = {
 			isa = PBXGroup;
 			children = (
-				BD87D1BD1B0CD38B00244049 /* VersionsDemoTests.swift */,
+				03C70A561B2421B000609F81 /* StaticVersion_Test.swift */,
+				03C70A571B2421B000609F81 /* Versions_Tests.swift */,
+				03C70A581B2421B000609F81 /* VersionsDemoTests.swift */,
 				BD87D1BB1B0CD38B00244049 /* Supporting Files */,
 			);
 			path = VersionsDemoTests;
@@ -119,14 +175,13 @@
 		BDD8224C1AA45FDD00E48CEF = {
 			isa = PBXGroup;
 			children = (
+				BD87D1A11B0CD38A00244049 /* VersionsDemo */,
+				BD87D1BA1B0CD38B00244049 /* VersionsDemoTests */,
+				03C709E01B24205A00609F81 /* Versions */,
+				BDD822581AA4608000E48CEF /* Products */,
 				BDD822611AA4608500E48CEF /* Versions.podspec */,
 				BDD822621AA4608500E48CEF /* LICENSE.md */,
 				BDD822631AA4608500E48CEF /* README.md */,
-				BDD822641AA4608500E48CEF /* Source */,
-				BDD822591AA4608000E48CEF /* Versions Tests */,
-				BD87D1A11B0CD38A00244049 /* VersionsDemo */,
-				BD87D1BA1B0CD38B00244049 /* VersionsDemoTests */,
-				BDD822581AA4608000E48CEF /* Products */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -135,43 +190,72 @@
 		BDD822581AA4608000E48CEF /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				BDD822571AA4608000E48CEF /* Versions Tests.xctest */,
 				BD87D1A01B0CD38A00244049 /* VersionsDemo.app */,
 				BD87D1B71B0CD38B00244049 /* VersionsDemoTests.xctest */,
+				03C709DF1B24205A00609F81 /* Version.framework */,
+				03C70A341B24210C00609F81 /* Version.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		BDD822591AA4608000E48CEF /* Versions Tests */ = {
-			isa = PBXGroup;
-			children = (
-				BDD8225C1AA4608000E48CEF /* Versions_Tests.swift */,
-				B5C505391AB0DA010090B67A /* StaticVersion_Test.swift */,
-				BDD8225A1AA4608000E48CEF /* Supporting Files */,
-			);
-			path = "Versions Tests";
-			sourceTree = "<group>";
-		};
-		BDD8225A1AA4608000E48CEF /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				BDD8225B1AA4608000E48CEF /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		BDD822641AA4608500E48CEF /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				BDD822681AA4609000E48CEF /* Versions.swift */,
-				B57C8ACB1AB0D2C700430F04 /* StaticVersion.swift */,
-			);
-			path = Source;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		03C709DC1B24205A00609F81 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C70A031B24209D00609F81 /* Versions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03C70A311B24210C00609F81 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C70A541B24216B00609F81 /* Versions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		03C709DE1B24205A00609F81 /* Versions-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03C709FC1B24205A00609F81 /* Build configuration list for PBXNativeTarget "Versions-iOS" */;
+			buildPhases = (
+				03C709DA1B24205A00609F81 /* Sources */,
+				03C709DB1B24205A00609F81 /* Frameworks */,
+				03C709DC1B24205A00609F81 /* Headers */,
+				03C709DD1B24205A00609F81 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Versions-iOS";
+			productName = Versions;
+			productReference = 03C709DF1B24205A00609F81 /* Version.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		03C70A331B24210C00609F81 /* Versions-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03C70A4D1B24210C00609F81 /* Build configuration list for PBXNativeTarget "Versions-OSX" */;
+			buildPhases = (
+				03C70A2F1B24210C00609F81 /* Sources */,
+				03C70A301B24210C00609F81 /* Frameworks */,
+				03C70A311B24210C00609F81 /* Headers */,
+				03C70A321B24210C00609F81 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Versions-OSX";
+			productName = "Versions-OSX";
+			productReference = 03C70A341B24210C00609F81 /* Version.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		BD87D19F1B0CD38A00244049 /* VersionsDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BD87D1C31B0CD38B00244049 /* Build configuration list for PBXNativeTarget "VersionsDemo" */;
@@ -179,10 +263,12 @@
 				BD87D19C1B0CD38A00244049 /* Sources */,
 				BD87D19D1B0CD38A00244049 /* Frameworks */,
 				BD87D19E1B0CD38A00244049 /* Resources */,
+				03C709FD1B24205A00609F81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				03C709F51B24205A00609F81 /* PBXTargetDependency */,
 			);
 			name = VersionsDemo;
 			productName = VersionsDemo;
@@ -207,40 +293,26 @@
 			productReference = BD87D1B71B0CD38B00244049 /* VersionsDemoTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		BDD822561AA4608000E48CEF /* Versions Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BDD822601AA4608000E48CEF /* Build configuration list for PBXNativeTarget "Versions Tests" */;
-			buildPhases = (
-				BDD822531AA4608000E48CEF /* Sources */,
-				BDD822541AA4608000E48CEF /* Frameworks */,
-				BDD822551AA4608000E48CEF /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Versions Tests";
-			productName = "Versions Tests";
-			productReference = BDD822571AA4608000E48CEF /* Versions Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		BDD8224D1AA45FDD00E48CEF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0640;
 				TargetAttributes = {
+					03C709DE1B24205A00609F81 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
+					03C70A331B24210C00609F81 = {
+						CreatedOnToolsVersion = 6.3.2;
+					};
 					BD87D19F1B0CD38A00244049 = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
 					BD87D1B61B0CD38B00244049 = {
 						CreatedOnToolsVersion = 6.3.2;
 						TestTargetID = BD87D19F1B0CD38A00244049;
-					};
-					BDD822561AA4608000E48CEF = {
-						CreatedOnToolsVersion = 6.3;
 					};
 				};
 			};
@@ -257,7 +329,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				BDD822561AA4608000E48CEF /* Versions Tests */,
+				03C709DE1B24205A00609F81 /* Versions-iOS */,
+				03C70A331B24210C00609F81 /* Versions-OSX */,
 				BD87D19F1B0CD38A00244049 /* VersionsDemo */,
 				BD87D1B61B0CD38B00244049 /* VersionsDemoTests */,
 			);
@@ -265,6 +338,20 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		03C709DD1B24205A00609F81 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03C70A321B24210C00609F81 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BD87D19E1B0CD38A00244049 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -282,21 +369,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BDD822551AA4608000E48CEF /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		03C709DA1B24205A00609F81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C70A041B24209D00609F81 /* Versions.swift in Sources */,
+				03C70A021B24209D00609F81 /* StaticVersion.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03C70A2F1B24210C00609F81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C70A551B24216B00609F81 /* Versions.swift in Sources */,
+				03C70A531B24216B00609F81 /* StaticVersion.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BD87D19C1B0CD38A00244049 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD87D1C51B0CD45700244049 /* Versions.swift in Sources */,
 				BD87D1AA1B0CD38A00244049 /* ViewController.swift in Sources */,
 				BD87D1A51B0CD38A00244049 /* AppDelegate.swift in Sources */,
 			);
@@ -306,25 +403,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD87D1C61B0CD68700244049 /* Versions.swift in Sources */,
-				BD87D1BE1B0CD38B00244049 /* VersionsDemoTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDD822531AA4608000E48CEF /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B5C5053A1AB0DA010090B67A /* StaticVersion_Test.swift in Sources */,
-				BDD822691AA4609000E48CEF /* Versions.swift in Sources */,
-				B57C8ACC1AB0D2C700430F04 /* StaticVersion.swift in Sources */,
-				BDD8225D1AA4608000E48CEF /* Versions_Tests.swift in Sources */,
+				03C70A5B1B2421B000609F81 /* Versions_Tests.swift in Sources */,
+				03C70A5A1B2421B000609F81 /* StaticVersion_Test.swift in Sources */,
+				03C70A5C1B2421B000609F81 /* VersionsDemoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		03C709F51B24205A00609F81 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 03C709DE1B24205A00609F81 /* Versions-iOS */;
+			targetProxy = 03C709F41B24205A00609F81 /* PBXContainerItemProxy */;
+		};
 		BD87D1B91B0CD38B00244049 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BD87D19F1B0CD38A00244049 /* VersionsDemo */;
@@ -352,6 +444,219 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		03C709F81B24205A00609F81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Versions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = Version;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		03C709F91B24205A00609F81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Versions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Version;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		03C70A4E1B24210C00609F81 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Versions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = Version;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		03C70A4F1B24210C00609F81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Versions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Version;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		BD87D1BF1B0CD38B00244049 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -540,6 +845,7 @@
 		BDD822511AA45FDD00E48CEF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -549,102 +855,25 @@
 			};
 			name = Release;
 		};
-		BDD8225E1AA4608000E48CEF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Versions Tests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Debug;
-		};
-		BDD8225F1AA4608000E48CEF /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Versions Tests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		03C709FC1B24205A00609F81 /* Build configuration list for PBXNativeTarget "Versions-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03C709F81B24205A00609F81 /* Debug */,
+				03C709F91B24205A00609F81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		03C70A4D1B24210C00609F81 /* Build configuration list for PBXNativeTarget "Versions-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03C70A4E1B24210C00609F81 /* Debug */,
+				03C70A4F1B24210C00609F81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		BD87D1C31B0CD38B00244049 /* Build configuration list for PBXNativeTarget "VersionsDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -652,6 +881,7 @@
 				BD87D1C01B0CD38B00244049 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		BD87D1C41B0CD38B00244049 /* Build configuration list for PBXNativeTarget "VersionsDemoTests" */ = {
 			isa = XCConfigurationList;
@@ -660,21 +890,13 @@
 				BD87D1C21B0CD38B00244049 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		BDD822501AA45FDD00E48CEF /* Build configuration list for PBXProject "Versions" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BDD822511AA45FDD00E48CEF /* Debug */,
 				BDD822521AA45FDD00E48CEF /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		BDD822601AA4608000E48CEF /* Build configuration list for PBXNativeTarget "Versions Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BDD8225E1AA4608000E48CEF /* Debug */,
-				BDD8225F1AA4608000E48CEF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Versions.xcodeproj/xcshareddata/xcschemes/Versions-OSX.xcscheme
+++ b/Versions.xcodeproj/xcshareddata/xcschemes/Versions-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "03C70A331B24210C00609F81"
-               BuildableName = "Versions-OSX.framework"
+               BuildableName = "Version.framework"
                BlueprintName = "Versions-OSX"
                ReferencedContainer = "container:Versions.xcodeproj">
             </BuildableReference>
@@ -29,6 +29,8 @@
       buildConfiguration = "Debug">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -38,12 +40,13 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "03C70A331B24210C00609F81"
-            BuildableName = "Versions-OSX.framework"
+            BuildableName = "Version.framework"
             BlueprintName = "Versions-OSX"
             ReferencedContainer = "container:Versions.xcodeproj">
          </BuildableReference>
@@ -61,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "03C70A331B24210C00609F81"
-            BuildableName = "Versions-OSX.framework"
+            BuildableName = "Version.framework"
             BlueprintName = "Versions-OSX"
             ReferencedContainer = "container:Versions.xcodeproj">
          </BuildableReference>

--- a/Versions.xcodeproj/xcshareddata/xcschemes/Versions-OSX.xcscheme
+++ b/Versions.xcodeproj/xcshareddata/xcschemes/Versions-OSX.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03C70A331B24210C00609F81"
+               BuildableName = "Versions-OSX.framework"
+               BlueprintName = "Versions-OSX"
+               ReferencedContainer = "container:Versions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C70A331B24210C00609F81"
+            BuildableName = "Versions-OSX.framework"
+            BlueprintName = "Versions-OSX"
+            ReferencedContainer = "container:Versions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C70A331B24210C00609F81"
+            BuildableName = "Versions-OSX.framework"
+            BlueprintName = "Versions-OSX"
+            ReferencedContainer = "container:Versions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Versions.xcodeproj/xcshareddata/xcschemes/Versions-iOS.xcscheme
+++ b/Versions.xcodeproj/xcshareddata/xcschemes/Versions-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,8 @@
       buildConfiguration = "Debug">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -38,6 +40,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Versions.xcodeproj/xcshareddata/xcschemes/Versions-iOS.xcscheme
+++ b/Versions.xcodeproj/xcshareddata/xcschemes/Versions-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BDD822561AA4608000E48CEF"
-               BuildableName = "Versions Tests.xctest"
-               BlueprintName = "Versions Tests"
+               BlueprintIdentifier = "03C709DE1B24205A00609F81"
+               BuildableName = "Version.framework"
+               BlueprintName = "Versions-iOS"
                ReferencedContainer = "container:Versions.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,26 +28,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BDD822561AA4608000E48CEF"
-               BuildableName = "Versions Tests.xctest"
-               BlueprintName = "Versions Tests"
-               ReferencedContainer = "container:Versions.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BDD822561AA4608000E48CEF"
-            BuildableName = "Versions Tests.xctest"
-            BlueprintName = "Versions Tests"
-            ReferencedContainer = "container:Versions.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -61,9 +42,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BDD822561AA4608000E48CEF"
-            BuildableName = "Versions Tests.xctest"
-            BlueprintName = "Versions Tests"
+            BlueprintIdentifier = "03C709DE1B24205A00609F81"
+            BuildableName = "Version.framework"
+            BlueprintName = "Versions-iOS"
             ReferencedContainer = "container:Versions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -79,9 +60,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BDD822561AA4608000E48CEF"
-            BuildableName = "Versions Tests.xctest"
-            BlueprintName = "Versions Tests"
+            BlueprintIdentifier = "03C709DE1B24205A00609F81"
+            BuildableName = "Version.framework"
+            BlueprintName = "Versions-iOS"
             ReferencedContainer = "container:Versions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Versions/Info.plist
+++ b/Versions/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>no.hyper.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Versions/Info.plist
+++ b/Versions/Info.plist
@@ -7,18 +7,20 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.zenangst.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>no.hyper.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Versions/StaticVersion.swift
+++ b/Versions/StaticVersion.swift
@@ -19,7 +19,8 @@ public struct Version : Equatable,  Comparable{
 
   
   public init?(_ version: String) {
-    let parts: Array<String> = split(version.characters) { $0 == "." }.map { String($0) }
+    
+    let parts: Array<String> = version.characters.split { $0 == "." }.map { String($0) }
     if let major = parts.at(0), minor = parts.at(1), patch = parts.at(2), majorInt = Int(major), minorInt = Int(minor), patchInt = Int(patch) {
       self.major = majorInt
       self.minor = minorInt

--- a/Versions/StaticVersion.swift
+++ b/Versions/StaticVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Array {
 
-  func at(index: Int) -> T? {
+  func at(index: Int) -> Element? {
     if index >= 0 && index < self.count {
       return self[index]
     }

--- a/Versions/StaticVersion.swift
+++ b/Versions/StaticVersion.swift
@@ -12,19 +12,17 @@ extension Array {
 
 public struct Version : Equatable,  Comparable{
 
-  let major: Int
-  let minor: Int
-  let patch: Int
+  public let major  : Int
+  public let minor  : Int
+  public let patch  : Int
+  public let string : String?
 
-  let string: String?
-
+  
   public init?(_ version: String) {
     let parts: Array<String> = split(version) { $0 == "." }
-
     let major = parts.at(0)?.toInt()
     let minor = parts.at(1)?.toInt()
     let patch = parts.at(2)?.toInt()
-
     if let major = major, minor = minor, patch = patch {
       self.major = major
       self.minor = minor
@@ -37,11 +35,13 @@ public struct Version : Equatable,  Comparable{
   }
 }
 
+
 //MARK: - Equatable
 
 public func == (lhs: Version, rhs: Version) -> Bool {
   return lhs.string == rhs.string
 }
+
 
 public func == (lhs: Version, rhs: Version?) -> Bool {
   switch (rhs) {
@@ -49,6 +49,7 @@ public func == (lhs: Version, rhs: Version?) -> Bool {
   case .None: return false
   }
 }
+
 
 //MARK: - Comparable
 

--- a/Versions/StaticVersion.swift
+++ b/Versions/StaticVersion.swift
@@ -19,14 +19,11 @@ public struct Version : Equatable,  Comparable{
 
   
   public init?(_ version: String) {
-    let parts: Array<String> = split(version) { $0 == "." }
-    let major = parts.at(0)?.toInt()
-    let minor = parts.at(1)?.toInt()
-    let patch = parts.at(2)?.toInt()
-    if let major = major, minor = minor, patch = patch {
-      self.major = major
-      self.minor = minor
-      self.patch = patch
+    let parts: Array<String> = split(version.characters) { $0 == "." }.map { String($0) }
+    if let major = parts.at(0), minor = parts.at(1), patch = parts.at(2), majorInt = Int(major), minorInt = Int(minor), patchInt = Int(patch) {
+      self.major = majorInt
+      self.minor = minorInt
+      self.patch = patchInt
       string = version
     } else {
       //Failed to Initialize Version

--- a/Versions/Versions.h
+++ b/Versions/Versions.h
@@ -1,0 +1,19 @@
+//
+//  Versions.h
+//  Versions
+//
+//  Created by 郑行之 on 6/7/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Versions.
+FOUNDATION_EXPORT double VersionsVersionNumber;
+
+//! Project version string for Versions.
+FOUNDATION_EXPORT const unsigned char VersionsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Versions/PublicHeader.h>
+
+

--- a/Versions/Versions.swift
+++ b/Versions/Versions.swift
@@ -21,7 +21,7 @@ public struct App {
 public extension String {
 
   public subscript (i: Int) -> Character {
-    return self[advance(self.startIndex, i)]
+    return self[self.startIndex.advancedBy(i)]
   }
 
   
@@ -31,7 +31,7 @@ public extension String {
   
 
   public subscript (r: Range<Int>) -> String {
-    return substringWithRange(Range(start: advance(startIndex, r.startIndex), end: advance(startIndex, r.endIndex)))
+    return substringWithRange(Range(start: startIndex.advancedBy(r.startIndex), end: startIndex.advancedBy(r.endIndex)))
   }
   
 

--- a/Versions/Versions.swift
+++ b/Versions/Versions.swift
@@ -6,66 +6,77 @@ public enum Semantic {
   case Major, Minor, Patch, Same, Unknown
 }
 
-struct App {
+public struct App {
 
-  static var version: String = {
+  public static var version: String = {
     var version: String = ""
     if let infoDictionary = NSBundle.mainBundle().infoDictionary {
       version = infoDictionary["CFBundleShortVersionString"] as! String
     }
-
     return version
-    }()
-
+  }()
 }
+
 
 public extension String {
 
-  subscript (i: Int) -> Character {
+  public subscript (i: Int) -> Character {
     return self[advance(self.startIndex, i)]
   }
 
-  subscript (i: Int) -> String {
+  
+  public subscript (i: Int) -> String {
     return String(self[i] as Character)
   }
+  
 
-  subscript (r: Range<Int>) -> String {
+  public subscript (r: Range<Int>) -> String {
     return substringWithRange(Range(start: advance(startIndex, r.startIndex), end: advance(startIndex, r.endIndex)))
   }
+  
 
-  var major: String {
+  public var major: String {
     return self[0]
   }
 
-  var minor: String {
+  
+  public var minor: String {
     return self[0...2]
   }
+  
 
-  var patch: String {
+  public var patch: String {
     return self[0...4]
   }
+  
 
-  func newerThan(version :String) -> Bool {
+  public func newerThan(version :String) -> Bool {
     return self.compare(version, options: NSStringCompareOptions.NumericSearch) == NSComparisonResult.OrderedDescending
   }
+  
 
-  func olderThan(version: String) -> Bool {
+  public func olderThan(version: String) -> Bool {
     let isEqual: Bool = self == version
     return !isEqual ? !self.newerThan(version) : false
   }
+  
 
-  func majorChange(version: String) -> Bool {
+  public func majorChange(version: String) -> Bool {
     return self.major != version.major
   }
-  func minorChange(version: String) -> Bool {
+  
+  
+  public func minorChange(version: String) -> Bool {
     return self.minor != version.minor && self.olderThan(version)
   }
-  func patchChange(version: String) -> Bool {
+  
+  
+  public func patchChange(version: String) -> Bool {
     return self.patch != version.patch && self.olderThan(version)
   }
+  
 
-  func semanticCompare(version: String) -> Semantic {
-
+  public func semanticCompare(version: String) -> Semantic {
     switch self {
     case _ where self == version:
       return .Same

--- a/VersionsDemo/Info.plist
+++ b/VersionsDemo/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>no.hyper.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VersionsDemo/ViewController.swift
+++ b/VersionsDemo/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Version
 
 class ViewController: UIViewController {
 

--- a/VersionsDemoTests/Info.plist
+++ b/VersionsDemoTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>no.hyper.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VersionsDemoTests/StaticVersion_Test.swift
+++ b/VersionsDemoTests/StaticVersion_Test.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import Version
 
 class StaticVersion_Test: XCTestCase {
 

--- a/VersionsDemoTests/VersionsDemoTests.swift
+++ b/VersionsDemoTests/VersionsDemoTests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import Version
 
 class VersionsDemoTests: XCTestCase {
 

--- a/VersionsDemoTests/Versions_Tests.swift
+++ b/VersionsDemoTests/Versions_Tests.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import XCTest
+import Version
 
 class Versions_Tests: XCTestCase {
 


### PR DESCRIPTION
Hi, I make some big changes over the Versions Frameworks. Including:
- Dynamic Frameworks for iOS / OSX.
- make some internal Versions API as 'public'.
- Clean the code a little bit.
- Carthage Support

Unfortunately, there are something I can't do / haven't do.
- I haven't change the Podspec file. So It's doesn't support CocoaPods in these Branch
- It seems Versions.framework is conflict with some other OS X Framework. So I have to use another framework name to avoid the problem.

Due to the two problems I mention. I'm not expecting this pull request is going to be merge into the master branch of Versions Framework. I just want to open a discussion about Carthage Supports. I tried similar framework and prefer 'Versions', and I would love to use it in my app.

Thank you.
