### PR TITLE
Update podspec version

### DIFF
--- a/Versions.podspec
+++ b/Versions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Versions"
-  s.version = "0.3.0"
+  s.version = "0.4.0"
   s.summary = "Helping you find inner peace when comparing version numbers in Swift."
   s.description = <<-DESC
                    * Helping you find inner peace when comparing version numbers in Swift.


### PR DESCRIPTION
I was trying to use this framework as part of my project with Xcode 7.2. But the 0.3.0 version (CocoaPod) was pointed to an older commit that was not compatible with the latest Swift.

Since pull request doesn't include Tags, I can only include changes to the podspec, someone with push access to the repository needs to create a corresponding CocoaPod version tag :)
